### PR TITLE
fix: default config was always applied at refresh

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,6 +9,6 @@ const config: Config.InitialOptions = {
     testEnvironment: "./tests/FixJSDOMEnvironment.ts",
     coveragePathIgnorePatterns: ["/node_modules/", "/src/controller/frames/weather/open-meteo-client", ".instance.ts"],
     coverageDirectory: "./reports/coverage",
-    reporters: [["github-actions", { silent: false }], "summary"],
+    reporters: [["github-actions", { silent: false }], "default"],
 };
 export default config;

--- a/src/controller/Main.ts
+++ b/src/controller/Main.ts
@@ -27,11 +27,11 @@ export class MainController extends BaseController<Settings> {
         void this.refresh();
     }
     set config(newConfig: Settings) {
-        this._model.config = newConfig;
+        ConfigModel.config = newConfig;
         void this.refresh();
     }
     get config(): Settings {
-        return this._model.config;
+        return ConfigModel.config;
     }
     protected addListener(): void {
         this.fullscreenButton.addListener("click", () => {

--- a/src/controller/SettingsPopup.ts
+++ b/src/controller/SettingsPopup.ts
@@ -14,11 +14,11 @@ export class SettingsPopupController extends BaseController<Settings> {
         this.loading = this.refresh();
     }
     set config(newConfig: Settings) {
-        this._model.config = newConfig;
+        ConfigModel.config = newConfig;
         this.loading = this.refresh();
     }
     get config(): Settings {
-        return this._model.config;
+        return ConfigModel.config;
     }
     protected addListener(): void {
         this.modal.addListener("show.bs.modal", () => {

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -23,29 +23,33 @@ export interface Settings {
 }
 
 export class ConfigModel extends Model<Settings> {
-    protected _config: Settings;
+    protected static _config: Settings | undefined;
     constructor() {
-        super(() => Promise.resolve(defaults));
-        this._config = this.load();
-        this.getData = this.getConfig.bind(this);
+        super(ConfigModel.getConfig.bind(ConfigModel));
     }
-    protected getConfig(): Promise<Settings> {
-        return Promise.resolve(this.config);
+    protected static getConfig(): Promise<Settings> {
+        return Promise.resolve(ConfigModel.config);
     }
-    get config(): Settings {
-        return this._config;
+    public static reset(): void {
+        this._config = undefined;
     }
-    set config(data: Settings) {
+    static get config(): Settings {
+        if (!ConfigModel._config) {
+            ConfigModel._config = ConfigModel.load();
+        }
+        return ConfigModel._config;
+    }
+    static set config(data: Settings) {
         this._config = data;
     }
     public save(): void {
         try {
-            localStorage.setItem("config", JSON.stringify(this.config));
+            localStorage.setItem("config", JSON.stringify(ConfigModel.config));
         } catch {
             // Do nothing, this is allowed to fail
         }
     }
-    public load(): Settings {
+    public static load(): Settings {
         try {
             const storedConfig = localStorage.getItem("config");
             if (!storedConfig) {
@@ -60,7 +64,7 @@ export class ConfigModel extends Model<Settings> {
         }
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private assertIsSettings(value: any): asserts value is Settings {
+    private static assertIsSettings(value: any): asserts value is Settings {
         if (
             !("sites" in value) ||
             !("rotationRate" in value) ||

--- a/tests/unit/controller/main.test.ts
+++ b/tests/unit/controller/main.test.ts
@@ -78,7 +78,7 @@ describe("Main Controller", () => {
                 refreshRate: 600,
             };
             controller.refreshView(newConfig);
-            expect(controller.config).toStrictEqual(configModel.config);
+            expect(controller.config).toStrictEqual(ConfigModel.config);
         });
         it("Adjusts frames in case frame config was changed", () => {
             const newConfig = {

--- a/tests/unit/controller/settingsPopup.test.ts
+++ b/tests/unit/controller/settingsPopup.test.ts
@@ -133,7 +133,7 @@ describe("Settings Popup Controller", () => {
                 refreshRate: 600,
             };
             controller.refreshView(newConfig);
-            expect(controller.configObject).toStrictEqual(configModel.config);
+            expect(controller.configObject).toStrictEqual(ConfigModel.config);
         });
         it("Throws error if provided with one", () => {
             expect(() => {

--- a/tests/unit/model/Config.test.ts
+++ b/tests/unit/model/Config.test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-import { defaults, ConfigModel } from "../../../src/models/Config";
+import { defaults, ConfigModel, Settings } from "../../../src/models/Config";
 
 describe("Config Model class", () => {
+    afterEach(() => {
+        ConfigModel.reset();
+    });
     describe("Save", () => {
         it("Saves to localStorage", () => {
             const model = new ConfigModel();
@@ -11,27 +14,37 @@ describe("Config Model class", () => {
     });
     describe("load", () => {
         it("Returns saved config from localStorage", () => {
-            const model = new ConfigModel();
             localStorage.setItem(
                 "config",
                 '{"sites":[{"url":"./frames/clock.html","rotationRate":60},{"url":"./frames/weather.html","rotationRate":60}],"useGlobalRotationRate":true,"rotationRate":60,"refreshRate":6000}',
             );
-            expect(model.load().refreshRate).toBe(6000);
+            expect(ConfigModel.load().refreshRate).toBe(6000);
         });
         it("Returns default values if saved config is invalid JSON", () => {
-            const model = new ConfigModel();
             localStorage.setItem("config", "invalid");
-            expect(model.load()).toStrictEqual(defaults);
+            expect(ConfigModel.load()).toStrictEqual(defaults);
         });
         it("Returns default values if saved config doesn't exist", () => {
-            const model = new ConfigModel();
             localStorage.removeItem("config");
-            expect(model.load()).toStrictEqual(defaults);
+            expect(ConfigModel.load()).toStrictEqual(defaults);
         });
         it("Returns default values if saved config type is incompatible", () => {
-            const model = new ConfigModel();
             localStorage.setItem("config", '{ "someValue": 20}');
-            expect(model.load()).toStrictEqual(defaults);
+            expect(ConfigModel.load()).toStrictEqual(defaults);
+        });
+        it("Non-default config is immediately loaded", async () => {
+            localStorage.setItem(
+                "config",
+                JSON.stringify({
+                    sites: [{ url: "./frames/clock.html", rotationRate: 60 }],
+                    useGlobalRotationRate: true,
+                    rotationRate: 70,
+                    refreshRate: 700,
+                }),
+            );
+            const model = new ConfigModel();
+            const res = await model.data;
+            expect((res as Settings).refreshRate).toBe(700);
         });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/SteveBlum/circum/issues/3
The default settings were always applied after a refresh even though saved custom settings from Web Storage  were available and loaded.